### PR TITLE
feat: support pnpm/yarn without npx downloads

### DIFF
--- a/src/app/runLinter.ts
+++ b/src/app/runLinter.ts
@@ -11,7 +11,12 @@ import { Effect } from "effect";
 
 import { computeExitCode } from "../core/decision.js";
 import type { ExitCode } from "../core/models.js";
-import type { CLIOptions, LintMessageWithFile } from "../core/types/index.js";
+import type {
+	CLIOptions,
+	LintMessageWithFile,
+	PackageManager,
+	PackageManagerSelection,
+} from "../core/types/index.js";
 import { checkAndReportPreflight } from "../shell/analysis/preflight.js";
 import { parseCLIArgs } from "../shell/config/cli.js";
 import { loadLinterConfig } from "../shell/config/index.js";
@@ -34,6 +39,10 @@ import {
 	checkDependencies,
 	reportMissingDependencies,
 } from "../shell/utils/dependencies.js";
+import {
+	formatInstallDevCommand,
+	resolvePackageManager,
+} from "../shell/utils/package-manager.js";
 
 /**
  * Collect diagnostics from all configured linters.
@@ -49,6 +58,7 @@ import {
  */
 function collectLintMessagesEffect(
 	targetPath: string,
+	packageManager: PackageManager,
 ): Effect.Effect<LintMessageWithFile[]> {
 	return Effect.gen(function* () {
 		// CHANGE: Use Effect.all with mode: "all" for concurrent execution
@@ -56,13 +66,13 @@ function collectLintMessagesEffect(
 		// INVARIANT: All linter effects are independent and can run concurrently
 		const [eslintResults, biomeResults, tsMessages] = yield* Effect.all(
 			[
-				getESLintResults(targetPath).pipe(
+				getESLintResults(targetPath, packageManager).pipe(
 					Effect.catchAll(() => Effect.succeed([])),
 				),
-				getBiomeDiagnostics(targetPath).pipe(
+				getBiomeDiagnostics(targetPath, packageManager).pipe(
 					Effect.catchAll(() => Effect.succeed([])),
 				),
-				getTypeScriptDiagnostics(targetPath).pipe(
+				getTypeScriptDiagnostics(targetPath, packageManager).pipe(
 					Effect.catchAll(() => Effect.succeed([])),
 				),
 			],
@@ -105,6 +115,13 @@ function collectLintMessagesEffect(
 	});
 }
 
+function makeResolvePackageManagerParams(
+	cwd: string,
+	selection: CLIOptions["packageManager"],
+): { readonly cwd: string; readonly selection?: PackageManagerSelection } {
+	return selection === undefined ? { cwd } : { cwd, selection };
+}
+
 /**
  * Handle duplicate reporting and cleanup of SARIF artifacts.
  *
@@ -142,9 +159,15 @@ function handleDuplicates(
  */
 function preflightOk(cliOptions: CLIOptions): boolean {
 	if (cliOptions.noPreflight) return true;
-	const pre = checkAndReportPreflight(process.cwd());
+	const pre = checkAndReportPreflight(process.cwd(), cliOptions.packageManager);
 	if (!pre.ok) {
 		if (cliOptions.fixPeers) {
+			const { packageManager } = resolvePackageManager(
+				makeResolvePackageManagerParams(
+					process.cwd(),
+					cliOptions.packageManager,
+				),
+			);
 			const needsTs = pre.issues.includes("missingTypescript");
 			const needsBiome = pre.issues.includes("missingBiome");
 			const pkgs: string[] = [];
@@ -152,7 +175,7 @@ function preflightOk(cliOptions: CLIOptions): boolean {
 			if (needsBiome) pkgs.push("@biomejs/biome");
 			if (pkgs.length > 0) {
 				console.error("Suggested install command:");
-				console.error(`  npm install --save-dev ${pkgs.join(" ")}`);
+				console.error(`  ${formatInstallDevCommand(packageManager, pkgs)}`);
 			}
 		}
 		return false;
@@ -165,11 +188,18 @@ function preflightOk(cliOptions: CLIOptions): boolean {
  *
  * @pure false (executes checks, console output)
  */
-function haveCliDependencies(): Effect.Effect<boolean> {
+function haveCliDependencies(params: {
+	readonly cwd: string;
+	readonly packageManager: PackageManager;
+}): Effect.Effect<boolean> {
 	return Effect.gen(function* (_) {
-		const depCheck = yield* _(checkDependencies());
+		const depCheck = yield* _(checkDependencies(params.cwd));
 		if (!depCheck.allAvailable) {
-			reportMissingDependencies(depCheck.missing);
+			reportMissingDependencies({
+				cwd: params.cwd,
+				packageManager: params.packageManager,
+				missing: depCheck.missing,
+			});
 			return false;
 		}
 		return true;
@@ -190,6 +220,7 @@ function haveCliDependencies(): Effect.Effect<boolean> {
 function maybeRunAutoFixEffect(
 	targetPath: string,
 	noFix: boolean,
+	packageManager: PackageManager,
 ): Effect.Effect<void> {
 	if (noFix) return Effect.succeed(undefined);
 
@@ -197,10 +228,10 @@ function maybeRunAutoFixEffect(
 	// WHY: Runs both auto-fixers in parallel, continues on individual failures
 	return Effect.all(
 		[
-			runESLintFix(targetPath).pipe(
+			runESLintFix(targetPath, packageManager).pipe(
 				Effect.catchAll(() => Effect.succeed(undefined)),
 			),
-			runBiomeFix(targetPath).pipe(
+			runBiomeFix(targetPath, packageManager).pipe(
 				Effect.catchAll(() => Effect.succeed(undefined)),
 			),
 		],
@@ -227,23 +258,35 @@ function maybeRunAutoFixEffect(
  */
 export function runLinter(cliOptions: CLIOptions): Effect.Effect<ExitCode> {
 	return Effect.gen(function* (_) {
+		const { packageManager } = resolvePackageManager(
+			makeResolvePackageManagerParams(process.cwd(), cliOptions.packageManager),
+		);
+
 		// CHANGE: Preflight checks remain sync for now (will be Effect-ified in future iteration)
 		// WHY: Incremental refactoring - focus on linter execution first
 		if (!preflightOk(cliOptions)) return 1;
 
-		const depsOk = yield* _(haveCliDependencies());
+		const depsOk = yield* _(
+			haveCliDependencies({ cwd: process.cwd(), packageManager }),
+		);
 		if (!depsOk) return 1;
 
 		console.log(`🔍 Linting directory: ${cliOptions.targetPath}`);
 
 		// CHANGE: Use Effect composition for auto-fix
 		// WHY: Consistent functional approach throughout pipeline
-		yield* _(maybeRunAutoFixEffect(cliOptions.targetPath, cliOptions.noFix));
+		yield* _(
+			maybeRunAutoFixEffect(
+				cliOptions.targetPath,
+				cliOptions.noFix,
+				packageManager,
+			),
+		);
 
 		// CHANGE: Use Effect composition for linter collection
 		// WHY: Consistent functional approach throughout pipeline
 		const allMessages = yield* _(
-			collectLintMessagesEffect(cliOptions.targetPath),
+			collectLintMessagesEffect(cliOptions.targetPath, packageManager),
 		);
 
 		// CHANGE: Use Effect composition for SARIF report generation with error handling

--- a/src/core/json.ts
+++ b/src/core/json.ts
@@ -1,0 +1,50 @@
+// CHANGE: Add shared JSON utility types and type guards
+// WHY: Multiple modules parse JSON (configs, package.json); shared helpers reduce duplication (jscpd threshold=0)
+// QUOTE(ТЗ): "Разумные рефакторинги без дубликатов"
+// REF: ISSUE-5 (pnpm/yarn support introduced new JSON parsing)
+// PURITY: CORE
+// INVARIANT: JSONValue is closed under JSON serialization; guards are total functions
+// COMPLEXITY: O(1)
+
+/**
+ * Type representing any valid JSON value.
+ *
+ * @invariant Must be serializable to JSON
+ */
+export type JSONValue =
+	| string
+	| number
+	| boolean
+	| null
+	| readonly JSONValue[]
+	| { readonly [key: string]: JSONValue };
+
+/**
+ * Type guard: JSON object (non-null, not an array).
+ */
+export function isJSONObject(
+	value: JSONValue,
+): value is Readonly<Record<string, JSONValue>> {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * Type guard: string.
+ */
+export function isString(value: JSONValue): value is string {
+	return typeof value === "string";
+}
+
+/**
+ * Type guard: number.
+ */
+export function isNumber(value: JSONValue): value is number {
+	return typeof value === "number";
+}
+
+/**
+ * Type guard: array.
+ */
+export function isArray(value: JSONValue): value is readonly JSONValue[] {
+	return Array.isArray(value);
+}

--- a/src/core/package-manager.ts
+++ b/src/core/package-manager.ts
@@ -1,0 +1,36 @@
+// CHANGE: Add pure package manager parsing helpers
+// WHY: CLI parsing and package.json parsing must share the same normalization without duplication (jscpd threshold=0)
+// QUOTE(ISSUE #5): "Надо что бы оно поддерживало pnpm, yarn"
+// REF: ISSUE-5
+// PURITY: CORE
+// INVARIANT: Returned values are members of the finite set {"npm","pnpm","yarn","auto"}
+// COMPLEXITY: O(1)
+
+import { match } from "ts-pattern";
+
+import type { PackageManager, PackageManagerSelection } from "./types/index.js";
+
+export function parsePackageManagerSelection(
+	value: string,
+): PackageManagerSelection | null {
+	const v = value.trim().toLowerCase();
+	if (v === "auto") return "auto";
+	const pm = parsePackageManagerField(v);
+	return pm === null ? null : pm;
+}
+
+export function parsePackageManagerField(value: string): PackageManager | null {
+	const trimmed = value.trim();
+	const at = trimmed.indexOf("@");
+	const name = (at === -1 ? trimmed : trimmed.slice(0, at)).toLowerCase();
+
+	const NPM: PackageManager = "npm";
+	const PNPM: PackageManager = "pnpm";
+	const YARN: PackageManager = "yarn";
+
+	return match(name)
+		.with("npm", () => NPM)
+		.with("pnpm", () => PNPM)
+		.with("yarn", () => YARN)
+		.otherwise(() => null);
+}

--- a/src/core/types/config.ts
+++ b/src/core/types/config.ts
@@ -35,6 +35,9 @@ export interface LinterConfig {
  * @property context Количество строк контекста для diff (зарезервировано)
  * @property noFix Флаг отключения автоисправлений
  */
+export type PackageManager = "npm" | "pnpm" | "yarn";
+export type PackageManagerSelection = PackageManager | "auto";
+
 export interface CLIOptions {
 	readonly targetPath: string;
 	readonly maxClones: number;
@@ -43,6 +46,7 @@ export interface CLIOptions {
 	readonly noFix: boolean;
 	readonly noPreflight: boolean;
 	readonly fixPeers: boolean;
+	readonly packageManager?: PackageManagerSelection;
 }
 
 /**

--- a/src/core/types/index.ts
+++ b/src/core/types/index.ts
@@ -8,6 +8,8 @@ export type {
 	CLIOptions,
 	ExecError,
 	LinterConfig,
+	PackageManager,
+	PackageManagerSelection,
 	PriorityLevel,
 } from "./config.js";
 export type {

--- a/src/shell/analysis/preflight.ts
+++ b/src/shell/analysis/preflight.ts
@@ -5,11 +5,21 @@
 // SOURCE: n/a
 
 import * as fs from "node:fs";
-import { createRequire } from "node:module";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { match } from "ts-pattern";
+
+import type {
+	PackageManager,
+	PackageManagerSelection,
+} from "../../core/types/index.js";
+import { canResolveFromCwd } from "../utils/node-resolve.js";
+import {
+	formatInstallDevCommand,
+	resolvePackageManager,
+} from "../utils/package-manager.js";
+import { buildToolCommand } from "../utils/tool-command.js";
 
 // CHANGE: Define __dirname and require equivalents for ES modules
 // WHY: package.json has "type": "module", __dirname and require are not available in ES modules
@@ -17,7 +27,6 @@ import { match } from "ts-pattern";
 // REF: ES module migration
 // SOURCE: Node.js ES modules documentation
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const require = createRequire(import.meta.url);
 
 /**
  * Preflight issue codes enumerating all invariant violations we can detect prior to run.
@@ -69,18 +78,7 @@ export function hasPackageJson(cwd: string): boolean {
  *
  * Postcondition: returns true if resolution succeeds, false otherwise.
  */
-export function canResolveFromCwd(moduleName: string, cwd: string): boolean {
-	try {
-		// CHANGE: bounded resolution via explicit paths
-		// WHY: Mirrors how Node resolves peer deps in consumer projects
-		// QUOTE(ТЗ): "Использовать версию инструмента проекта"
-		// REF: REQ-CLI-PREFLIGHT-PEERS
-		require.resolve(moduleName, { paths: [cwd] });
-		return true;
-	} catch {
-		return false;
-	}
-}
+// NOTE: canResolveFromCwd moved to utils/node-resolve.ts for reuse across modules.
 
 /**
  * Detect if running from an isolated npx cache directory (advisory).
@@ -209,21 +207,49 @@ function printNoPackageJson(): void {
  *
  * Invariant: TypeScript must be installed in the consumer project
  */
-// CHANGE: extract small printer to reduce lines in dispatcher
-// WHY: satisfy max-lines-per-function without losing clarity
-// QUOTE(LINT): "Function has too many lines (max 50)"
-// REF: ESLint max-lines-per-function
-function printMissingTypescript(): void {
+interface PreflightPrintContext {
+	readonly cwd: string;
+	readonly packageManager: PackageManager;
+}
+
+function printInstallAndVerify(params: {
+	readonly ctx: PreflightPrintContext;
+	readonly installPackages: readonly string[];
+	readonly verifyBin: string;
+	readonly verifyArgs: readonly string[];
+}): void {
+	console.error("    Install:");
+	console.error(
+		`      ${formatInstallDevCommand(params.ctx.packageManager, params.installPackages)}`,
+	);
+	console.error("    Verify:");
+	console.error(
+		`      ${buildToolCommand({
+			cwd: params.ctx.cwd,
+			packageManager: params.ctx.packageManager,
+			bin: params.verifyBin,
+			args: params.verifyArgs,
+		})}\n`,
+	);
+}
+
+// CHANGE: Extract small printers that depend on detected package manager
+// WHY: Keep dispatcher small while supporting pnpm/yarn install and verify commands
+// QUOTE(ISSUE #5): "Надо что бы оно поддерживало pnpm, yarn"
+// REF: ISSUE-5
+function printMissingTypescript(ctx: PreflightPrintContext): void {
 	console.error(
 		"  • TypeScript (typescript) is not installed in this project.",
 	);
 	console.error(
 		"    Why: vibecode-linter uses your project's TypeScript as a peer dependency.",
 	);
-	console.error("    Install:");
-	console.error("      npm install --save-dev typescript");
-	console.error("    Verify:");
-	console.error("      npx tsc --version\n");
+	printInstallAndVerify({
+		ctx,
+		installPackages: ["typescript"],
+		verifyBin: "tsc",
+		verifyArgs: ["--version"],
+	});
 }
 
 /**
@@ -231,21 +257,19 @@ function printMissingTypescript(): void {
  *
  * Invariant: Biome CLI must be installed in the consumer project
  */
-// CHANGE: extract small printer to reduce lines in dispatcher
-// WHY: satisfy max-lines-per-function without losing clarity
-// QUOTE(LINT): "Function has too many lines (max 50)"
-// REF: ESLint max-lines-per-function
-function printMissingBiome(): void {
+function printMissingBiome(ctx: PreflightPrintContext): void {
 	console.error(
 		"  • Biome CLI (@biomejs/biome) is not installed in this project.",
 	);
 	console.error(
 		"    Why: vibecode-linter runs Biome as an external tool from your node_modules.",
 	);
-	console.error("    Install:");
-	console.error("      npm install --save-dev @biomejs/biome");
-	console.error("    Verify:");
-	console.error("      npx biome --version\n");
+	printInstallAndVerify({
+		ctx,
+		installPackages: ["@biomejs/biome"],
+		verifyBin: "biome",
+		verifyArgs: ["--version"],
+	});
 }
 
 /**
@@ -258,6 +282,7 @@ function printMissingBiome(): void {
  */
 function printBlockingIssues(
 	blockingIssues: readonly PreflightIssueCode[],
+	ctx: PreflightPrintContext,
 ): void {
 	console.error(
 		"\n[ERROR] Environment preflight failed. Please resolve the following issues:\n",
@@ -274,10 +299,10 @@ function printBlockingIssues(
 				printNoPackageJson();
 			})
 			.with("missingTypescript", () => {
-				printMissingTypescript();
+				printMissingTypescript(ctx);
 			})
 			.with("missingBiome", () => {
-				printMissingBiome();
+				printMissingBiome(ctx);
 			})
 			.with("npxIsolated", () => {
 				// Advisory-only: handled as warning elsewhere; not a blocker
@@ -292,6 +317,7 @@ function printBlockingIssues(
 // REF: ESLint max-lines-per-function
 function printAdvisoryWarnings(
 	advisories: readonly PreflightIssueCode[],
+	ctx: PreflightPrintContext,
 ): void {
 	if (advisories.length === 0) return;
 	// Currently the only advisory is npxIsolated
@@ -302,9 +328,18 @@ function printAdvisoryWarnings(
 		);
 		console.warn("       Recommended:");
 		console.warn(
-			"         npm install --save-dev @ton-ai-core/vibecode-linter",
+			`         ${formatInstallDevCommand(ctx.packageManager, [
+				"@ton-ai-core/vibecode-linter",
+			])}`,
 		);
-		console.warn("         npx @ton-ai-core/vibecode-linter <path>\n");
+		console.warn(
+			`         ${buildToolCommand({
+				cwd: ctx.cwd,
+				packageManager: ctx.packageManager,
+				bin: "vibecode-linter",
+				args: ["<path>"],
+			})}\n`,
+		);
 	}
 }
 
@@ -315,6 +350,12 @@ function printAdvisoryWarnings(
  */
 export function printPreflightReport(
 	issues: readonly PreflightIssueCode[],
+	options: {
+		readonly cwd?: string;
+		readonly selection?: PackageManagerSelection;
+	} = {
+		cwd: process.cwd(),
+	},
 ): void {
 	// CHANGE: Keep this function concise by delegating detailed output to helpers
 	// WHY: Satisfy max-lines-per-function while preserving actionable guidance
@@ -322,13 +363,21 @@ export function printPreflightReport(
 	// REF: ESLint max-lines-per-function
 	if (issues.length === 0) return;
 
+	const cwd = options.cwd ?? process.cwd();
+	const pmParams =
+		options.selection === undefined
+			? { cwd }
+			: { cwd, selection: options.selection };
+	const { packageManager } = resolvePackageManager(pmParams);
+	const ctx: PreflightPrintContext = { cwd, packageManager };
+
 	const blockingIssues = issues.filter((c) => c !== "npxIsolated");
 	const advisories = issues.filter((c) => c === "npxIsolated");
 
 	if (blockingIssues.length > 0) {
-		printBlockingIssues(blockingIssues);
+		printBlockingIssues(blockingIssues, ctx);
 	}
-	printAdvisoryWarnings(advisories);
+	printAdvisoryWarnings(advisories, ctx);
 }
 
 /**
@@ -338,9 +387,11 @@ export function printPreflightReport(
  */
 export function checkAndReportPreflight(
 	cwd: string = process.cwd(),
+	selection?: PackageManagerSelection,
 ): PreflightResult {
 	const result = runPreflight(cwd);
-	printPreflightReport(result.issues);
+	const reportOpts = selection === undefined ? { cwd } : { cwd, selection };
+	printPreflightReport(result.issues, reportOpts);
 	return result;
 }
 

--- a/src/shell/config/cli.ts
+++ b/src/shell/config/cli.ts
@@ -4,7 +4,12 @@
 // REF: REQ-20250210-MODULAR-ARCH
 // SOURCE: n/a
 
-import type { CLIOptions } from "../../core/types/index.js";
+import { parsePackageManagerSelection } from "../../core/package-manager.js";
+
+import type {
+	CLIOptions,
+	PackageManagerSelection,
+} from "../../core/types/index.js";
 
 // CHANGE: Extracted result type for argument processing
 // WHY: Simplifies control flow in parseCLIArgs
@@ -18,6 +23,7 @@ interface ArgProcessResult {
 	readonly noFix: boolean;
 	readonly noPreflight: boolean;
 	readonly fixPeers: boolean;
+	readonly packageManager: PackageManagerSelection;
 	readonly targetPath: string;
 	readonly skipNext: boolean;
 }
@@ -32,6 +38,22 @@ type NumericFlagHandler = (
 	index: number,
 	current: Omit<ArgProcessResult, "skipNext">,
 ) => ArgProcessResult | null;
+
+// CHANGE: Extracted string flag handler type for flags with a string value (e.g. package manager)
+// WHY: Keep processArgument complexity under the threshold by using handler maps
+// REF: ESLint complexity
+type StringFlagHandler = (
+	args: readonly string[],
+	index: number,
+	current: Omit<ArgProcessResult, "skipNext">,
+) => ArgProcessResult | null;
+
+// CHANGE: Extract boolean flag handler map to keep processArgument complexity under threshold
+// WHY: ESLint complexity rule limits branching
+// REF: ESLint complexity
+type BooleanFlagHandler = (
+	current: Omit<ArgProcessResult, "skipNext">,
+) => ArgProcessResult;
 
 // CHANGE: Created handlers for numeric flags
 // WHY: Eliminates branching in processArgument
@@ -52,6 +74,34 @@ const numericHandlers: Record<string, NumericFlagHandler> = {
 	"--max-clones": createNumericFlagHandler("maxClones"),
 	"--width": createNumericFlagHandler("width"),
 	"--context": createNumericFlagHandler("context"),
+};
+
+// CHANGE: Created handlers for string flags
+// WHY: Avoid branching in processArgument for flags that take a value
+// REF: ESLint complexity
+function createStringFlagHandler(key: "packageManager"): StringFlagHandler {
+	return (args, index, current) => {
+		if (index + 1 >= args.length) return null;
+		const raw = args[index + 1] ?? "";
+		const parsed = parsePackageManagerSelection(raw);
+		if (parsed === null) return null;
+		return { ...current, [key]: parsed, skipNext: true };
+	};
+}
+
+const stringHandlers: Record<string, StringFlagHandler> = {
+	"--pm": createStringFlagHandler("packageManager"),
+	"--package-manager": createStringFlagHandler("packageManager"),
+};
+
+const booleanHandlers: Record<string, BooleanFlagHandler> = {
+	"--no-fix": (current) => ({ ...current, noFix: true, skipNext: false }),
+	"--no-preflight": (current) => ({
+		...current,
+		noPreflight: true,
+		skipNext: false,
+	}),
+	"--fix-peers": (current) => ({ ...current, fixPeers: true, skipNext: false }),
 };
 
 // CHANGE: Simplified argument processor with handler map
@@ -77,23 +127,21 @@ function processArgument(
 		if (result !== null) return result;
 	}
 
+	// Try string flag handlers
+	const stringHandler: StringFlagHandler | undefined = (
+		stringHandlers as Record<string, StringFlagHandler | undefined>
+	)[arg];
+	if (stringHandler !== undefined) {
+		const result = stringHandler(args, index, current);
+		if (result !== null) return result;
+	}
+
 	// Handle boolean flags
-	if (arg === "--no-fix") {
-		return { ...current, noFix: true, skipNext: false };
-	}
-	if (arg === "--no-preflight") {
-		// CHANGE: Add --no-preflight flag to bypass environment checks
-		// WHY: Allow CI or advanced users to skip preflight explicitly
-		// QUOTE(ТЗ): "Добавить CLI флаги"
-		// REF: REQ-CLI-PREFLIGHT-PEERS
-		return { ...current, noPreflight: true, skipNext: false };
-	}
-	if (arg === "--fix-peers") {
-		// CHANGE: Add --fix-peers flag to print suggested install commands for missing peers
-		// WHY: Provide actionable remediation guidance
-		// QUOTE(ТЗ): "Писать внятно что необходимо сделать"
-		// REF: REQ-CLI-PREFLIGHT-PEERS
-		return { ...current, fixPeers: true, skipNext: false };
+	const boolHandler: BooleanFlagHandler | undefined = (
+		booleanHandlers as Record<string, BooleanFlagHandler | undefined>
+	)[arg];
+	if (boolHandler !== undefined) {
+		return boolHandler(current);
 	}
 
 	// Handle positional argument
@@ -132,6 +180,7 @@ export function parseCLIArgs(): CLIOptions {
 		noFix: false,
 		noPreflight: false,
 		fixPeers: false,
+		packageManager: "auto",
 	};
 
 	for (let i = 0; i < args.length; i++) {
@@ -154,7 +203,7 @@ export function parseCLIArgs(): CLIOptions {
 	// QUOTE(ТЗ): "Разумные рефакторинги без дубликатов"
 	// REF: REQ-LINT-FIX
 	const { context, ...rest } = state;
-	const base: Omit<CLIOptions, "context"> = {
+	const base: Omit<CLIOptions, "context" | "packageManager"> = {
 		targetPath: rest.targetPath,
 		maxClones: rest.maxClones,
 		width: rest.width,
@@ -162,6 +211,11 @@ export function parseCLIArgs(): CLIOptions {
 		noPreflight: rest.noPreflight,
 		fixPeers: rest.fixPeers,
 	};
+	// exactOptionalPropertyTypes: omit optional fields instead of setting them to undefined
+	const withPm: Omit<CLIOptions, "context"> =
+		rest.packageManager === "auto"
+			? base
+			: { ...base, packageManager: rest.packageManager };
 	// exactOptionalPropertyTypes: отсутствие поля корректно моделирует "context?: number"
-	return context === undefined ? base : { ...base, context };
+	return context === undefined ? withPm : { ...withPm, context };
 }

--- a/src/shell/config/loader.ts
+++ b/src/shell/config/loader.ts
@@ -11,62 +11,14 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 
+import {
+	isArray,
+	isJSONObject,
+	isNumber,
+	isString,
+	type JSONValue,
+} from "../../core/json.js";
 import type { LinterConfig, PriorityLevel } from "../../core/types/index.js";
-
-/**
- * Type representing any valid JSON value.
- *
- * @invariant Must be serializable to JSON
- */
-type JSONValue =
-	| string
-	| number
-	| boolean
-	| null
-	| readonly JSONValue[]
-	| { readonly [key: string]: JSONValue };
-
-/**
- * Type guard to check if value is a JSON object.
- *
- * @param value Value to check
- * @returns True if value is a non-null object
- */
-function isJSONObject(
-	value: JSONValue,
-): value is Readonly<Record<string, JSONValue>> {
-	return value !== null && typeof value === "object" && !Array.isArray(value);
-}
-
-/**
- * Type guard to check if value is a string.
- *
- * @param value Value to check
- * @returns True if value is a string
- */
-function isString(value: JSONValue): value is string {
-	return typeof value === "string";
-}
-
-/**
- * Type guard to check if value is a number.
- *
- * @param value Value to check
- * @returns True if value is a number
- */
-function isNumber(value: JSONValue): value is number {
-	return typeof value === "number";
-}
-
-/**
- * Type guard to check if value is an array.
- *
- * @param value Value to check
- * @returns True if value is an array
- */
-function isArray(value: JSONValue): value is readonly JSONValue[] {
-	return Array.isArray(value);
-}
 
 /**
  * Type representing a priority level object from JSON.

--- a/src/shell/linters/biome.ts
+++ b/src/shell/linters/biome.ts
@@ -17,8 +17,10 @@ import { promisify } from "node:util";
 import { Effect, pipe } from "effect";
 
 import { ExternalToolError, type ParseError } from "../../core/errors.js";
+import type { PackageManager } from "../../core/types/index.js";
 import { extractStdoutFromError } from "../../core/types/index.js";
 import { execCommand } from "../utils/exec.js";
+import { buildToolCommand } from "../utils/tool-command.js";
 import { type BiomeResult, parseBiomeOutput } from "./biome-parser.js";
 import { extractStdoutOrThrow } from "./linter-helpers.js";
 
@@ -43,9 +45,15 @@ const execAsync = promisify(exec);
  */
 export function runBiomeFix(
 	targetPath: string,
+	packageManager: PackageManager,
 ): Effect.Effect<void, ExternalToolError> {
 	return Effect.gen(function* () {
-		const biomeFixCommand = `npx biome check --write "${targetPath}"`;
+		const biomeFixCommand = buildToolCommand({
+			cwd: process.cwd(),
+			packageManager,
+			bin: "biome",
+			args: ["check", "--write", targetPath],
+		});
 		console.log(`🔧 Running Biome auto-fix on: ${targetPath}`);
 		// CHANGE: Log exact Biome CLI command for reproducibility
 		// WHY: Allows manual reruns that mirror automatic auto-fix behavior
@@ -110,11 +118,17 @@ export function runBiomeFix(
  */
 export function getBiomeDiagnostics(
 	targetPath: string,
+	packageManager: PackageManager,
 ): Effect.Effect<readonly BiomeResult[], ExternalToolError | ParseError> {
 	return Effect.gen(function* () {
 		// CHANGE: Use Effect.promise to always get stdout (even on non-zero exit)
 		// WHY: Biome returns non-zero on lint errors but with valid JSON
-		const biomeDiagnosticsCommand = `npx biome check "${targetPath}" --reporter=json`;
+		const biomeDiagnosticsCommand = buildToolCommand({
+			cwd: process.cwd(),
+			packageManager,
+			bin: "biome",
+			args: ["check", targetPath, "--reporter=json"],
+		});
 		// CHANGE: Log Biome diagnostics invocation when it actually executes
 		// WHY: Display reproducible command inline instead of at start
 		// QUOTE(USER-LOG-CMDS): "как только их вызывает он бы писал что за команду"
@@ -159,7 +173,10 @@ export function getBiomeDiagnostics(
 			!targetPath.endsWith(".tsx");
 		if (shouldFallback) {
 			console.log("🔄 Biome: Falling back to individual file checking...");
-			return yield* getBiomeDiagnosticsPerFileEffect(targetPath);
+			return yield* getBiomeDiagnosticsPerFileEffect(
+				targetPath,
+				packageManager,
+			);
 		}
 
 		return parsed.diagnostics;
@@ -183,10 +200,11 @@ export function getBiomeDiagnostics(
  */
 function getBiomeDiagnosticsPerFileEffect(
 	targetPath: string,
+	packageManager: PackageManager,
 ): Effect.Effect<readonly BiomeResult[], ExternalToolError> {
 	return Effect.gen(function* () {
 		const files = yield* listBiomeTargetFiles(targetPath);
-		return yield* collectPerFileDiagnostics(files);
+		return yield* collectPerFileDiagnostics(files, packageManager);
 	});
 }
 
@@ -240,11 +258,12 @@ const listBiomeTargetFiles = (
 // COMPLEXITY: O(n) where n = |files|
 const collectPerFileDiagnostics = (
 	files: readonly string[],
+	packageManager: PackageManager,
 ): Effect.Effect<readonly BiomeResult[]> =>
 	Effect.gen(function* () {
 		const allResults: BiomeResult[] = [];
 		for (const file of files) {
-			const diagnostics = yield* runBiomeCheckForFile(file);
+			const diagnostics = yield* runBiomeCheckForFile(file, packageManager);
 			allResults.push(...diagnostics);
 		}
 		return allResults;
@@ -262,8 +281,16 @@ const collectPerFileDiagnostics = (
 // COMPLEXITY: O(1) per file (Biome CLI dominates)
 const runBiomeCheckForFile = (
 	file: string,
+	packageManager: PackageManager,
 ): Effect.Effect<readonly BiomeResult[]> =>
-	execCommand(`npx biome check "${file}" --reporter=json`)
+	execCommand(
+		buildToolCommand({
+			cwd: process.cwd(),
+			packageManager,
+			bin: "biome",
+			args: ["check", file, "--reporter=json"],
+		}),
+	)
 		.pipe(Effect.catchAll(() => Effect.succeed("")))
 		.pipe(
 			Effect.flatMap((stdout) =>

--- a/src/shell/linters/eslint.ts
+++ b/src/shell/linters/eslint.ts
@@ -17,12 +17,25 @@ import { promisify } from "node:util";
 import { Effect } from "effect";
 
 import { ExternalToolError, ParseError } from "../../core/errors.js";
-import type { LintResult } from "../../core/types/index.js";
+import type { LintResult, PackageManager } from "../../core/types/index.js";
 import { extractStdoutFromError } from "../../core/types/index.js";
 import { execCommand } from "../utils/exec.js";
+import { buildToolCommand } from "../utils/tool-command.js";
 import { extractStdoutOrThrow } from "./linter-helpers.js";
 
 const execAsync = promisify(exec);
+
+function buildESLintCommand(
+	packageManager: PackageManager,
+	args: readonly string[],
+): string {
+	return buildToolCommand({
+		cwd: process.cwd(),
+		packageManager,
+		bin: "eslint",
+		args,
+	});
+}
 
 /**
  * Интерфейс результата ESLint (использует базовый LintResult).
@@ -44,11 +57,17 @@ export type ESLintResult = LintResult;
  * @effect Effect<void, ExternalToolError>
  * @invariant targetPath не пустой
  */
-export function runESLintFix(
+export const runESLintFix = (
 	targetPath: string,
-): Effect.Effect<void, ExternalToolError> {
-	return Effect.gen(function* () {
-		const eslintCommand = `npx eslint "${targetPath}" --ext .ts,.tsx --fix`;
+	packageManager: PackageManager,
+): Effect.Effect<void, ExternalToolError> =>
+	Effect.gen(function* () {
+		const eslintCommand = buildESLintCommand(packageManager, [
+			targetPath,
+			"--ext",
+			".ts,.tsx",
+			"--fix",
+		]);
 		console.log(`🔧 Running ESLint auto-fix on: ${targetPath}`);
 		// CHANGE: Surface exact ESLint command for reproducibility
 		// WHY: Operator must be able to rerun the same invocation outside vibecode-linter
@@ -92,7 +111,6 @@ export function runESLintFix(
 
 		console.log(`✅ ESLint auto-fix completed`);
 	});
-}
 
 /**
  * Получает результаты ESLint для указанного пути.
@@ -112,9 +130,16 @@ export function runESLintFix(
  */
 export function getESLintResults(
 	targetPath: string,
+	packageManager: PackageManager,
 ): Effect.Effect<readonly ESLintResult[], ExternalToolError | ParseError> {
 	return Effect.gen(function* () {
-		const eslintCommand = `npx eslint "${targetPath}" --ext .ts,.tsx --format json`;
+		const eslintCommand = buildESLintCommand(packageManager, [
+			targetPath,
+			"--ext",
+			".ts,.tsx",
+			"--format",
+			"json",
+		]);
 		// CHANGE: Log ESLint diagnostics invocation exactly when it runs
 		// WHY: Give operators immediate visibility into the command they can replay
 		// QUOTE(USER-LOG-CMDS): "Я хочу что бы он как только их вызывает он бы писал что за команду"

--- a/src/shell/linters/typescript.ts
+++ b/src/shell/linters/typescript.ts
@@ -14,7 +14,11 @@ import { Effect, pipe } from "effect";
 import ts from "typescript";
 
 import { InvariantViolation, ParseError } from "../../core/errors.js";
-import type { TypeScriptMessage } from "../../core/types/index.js";
+import type {
+	PackageManager,
+	TypeScriptMessage,
+} from "../../core/types/index.js";
+import { buildToolCommand } from "../utils/tool-command.js";
 
 // CHANGE: Add optional debug logger controlled by env VCL_DEBUG_TS
 // WHY: Diagnose where diagnostics are lost: project selection, pre/post filter counts
@@ -390,12 +394,18 @@ function getProgramDiagnostics(
  */
 export function getTypeScriptDiagnostics(
 	targetPath: string,
+	packageManager: PackageManager,
 ): Effect.Effect<
 	readonly TypeScriptMessage[],
 	ParseError | InvariantViolation
 > {
 	return Effect.gen(function* () {
-		const equivalentCommand = `npx tsc --project tsconfig.json --noEmit --pretty false`;
+		const equivalentCommand = buildToolCommand({
+			cwd: process.cwd(),
+			packageManager,
+			bin: "tsc",
+			args: ["--project", "tsconfig.json", "--noEmit", "--pretty", "false"],
+		});
 		// CHANGE: Log TypeScript diagnostic equivalent command on execution
 		// WHY: Although diagnostics run via Compiler API, operators need a CLI they can replay
 		// QUOTE(USER-LOG-CMDS): "Потом хочу видеть команды для вызова ошибок ... typescript"

--- a/src/shell/output/duplicates.ts
+++ b/src/shell/output/duplicates.ts
@@ -12,6 +12,7 @@ import type {
 	SarifReport,
 	SarifResult,
 } from "../../core/types/index.js";
+import { buildJscpdCommand } from "../utils/jscpd.js";
 // CHANGE: Use node: protocol for Node.js built-in modules
 // WHY: Biome lint rule requires explicit node: prefix for clarity
 // REF: lint/style/useNodejsImportProtocol
@@ -93,12 +94,10 @@ export function generateSarifReport(
 	targetPath: string,
 ): Effect.Effect<string, Error> {
 	const reportsDir = ensureReportsDir();
+	const jscpdCommand = buildJscpdCommand({ reportsDir, targetPath });
 
 	return Effect.tryPromise({
-		try: () =>
-			execAsync(
-				`npx jscpd --reporters sarif --output ${reportsDir} ${targetPath}`,
-			),
+		try: () => execAsync(jscpdCommand),
 		catch: () => null, // jscpd exits with non-zero when duplicates are found; ignore to proceed parsing
 	}).pipe(
 		Effect.flatMap(() => Effect.sync(() => discoverSarifArtifact(reportsDir))),

--- a/src/shell/utils/dependencies.ts
+++ b/src/shell/utils/dependencies.ts
@@ -1,81 +1,78 @@
-// CHANGE: Created dependency checker module
-// WHY: Need to verify required tools are installed before running linter
-// QUOTE(USER): "Надо проверять установлены ли они. Если не установлены говорить об их установке"
-// REF: user-request-check-dependencies
-// SOURCE: n/a
+// CHANGE: Rework dependency checks to avoid npx implicit downloads and support pnpm/yarn projects
+// WHY: `npx biome` can download legacy `biome` package; we must check/execute project-installed peers deterministically
+// QUOTE(ISSUE #5): "Надо что бы оно поддерживало pnpm, yarn"
+// REF: ISSUE-5
+// PURITY: SHELL (executes commands, inspects environment)
+// EFFECT: Effect<DependencyCheckResult>
+// INVARIANT: Missing list contains only required dependencies that are actually unavailable
+// COMPLEXITY: O(n) where n = number of dependencies checked
 
 import { exec } from "node:child_process";
 import { promisify } from "node:util";
 
 import { Effect } from "effect";
+import { match } from "ts-pattern";
+
+import type { PackageManager } from "../../core/types/index.js";
+import { canResolveFromCwd } from "./node-resolve.js";
+import { formatInstallDevCommand } from "./package-manager.js";
 
 const execAsync = promisify(exec);
 
-/**
- * Информация о зависимости.
- */
-interface Dependency {
-	readonly name: string;
-	readonly command: string;
-	readonly checkCommand: string;
-	readonly installCommand: string;
-	readonly required: boolean;
-}
+type Dependency =
+	| {
+			readonly kind: "command";
+			readonly name: string;
+			readonly checkCommand: string;
+			readonly installHint: string;
+			readonly required: true;
+	  }
+	| {
+			readonly kind: "package";
+			readonly name: string;
+			readonly packageJson: string;
+			readonly installPackages: readonly string[];
+			readonly required: true;
+	  };
 
-/**
- * Список всех необходимых зависимостей.
- */
 const DEPENDENCIES: readonly Dependency[] = [
 	{
+		kind: "command",
 		name: "Git",
-		command: "git",
 		checkCommand: "git --version",
-		installCommand: "Visit https://git-scm.com/downloads",
+		installHint: "Visit https://git-scm.com/downloads",
 		required: true,
 	},
 	{
+		kind: "command",
 		name: "Node.js",
-		command: "node",
 		checkCommand: "node --version",
-		installCommand: "Visit https://nodejs.org/",
+		installHint: "Visit https://nodejs.org/",
 		required: true,
 	},
 	{
+		kind: "package",
 		name: "ESLint",
-		command: "eslint",
-		checkCommand: "npx eslint --version",
-		installCommand: "npm install",
+		packageJson: "eslint/package.json",
+		installPackages: ["eslint"],
 		required: true,
 	},
 	{
+		kind: "package",
 		name: "Biome",
-		command: "biome",
-		checkCommand: "npx biome --version",
-		installCommand: "npm install",
+		packageJson: "@biomejs/biome/package.json",
+		installPackages: ["@biomejs/biome"],
 		required: true,
 	},
 	{
+		kind: "package",
 		name: "TypeScript",
-		command: "tsc",
-		checkCommand: "npx tsc --version",
-		installCommand: "npm install",
-		required: true,
-	},
-	{
-		name: "jscpd",
-		command: "jscpd",
-		checkCommand: "npx jscpd --version",
-		installCommand: "npm install",
+		packageJson: "typescript/package.json",
+		installPackages: ["typescript"],
 		required: true,
 	},
 ];
 
-/**
- * Проверяет доступность команды.
- *
- * @param checkCommand Команда для проверки
- * @returns True если команда доступна
- */
 function isCommandAvailable(checkCommand: string): Effect.Effect<boolean> {
 	return Effect.tryPromise({
 		try: () => execAsync(checkCommand, { timeout: 5000 }),
@@ -86,26 +83,40 @@ function isCommandAvailable(checkCommand: string): Effect.Effect<boolean> {
 	);
 }
 
+function isDependencyAvailable(
+	dep: Dependency,
+	cwd: string,
+): Effect.Effect<boolean> {
+	return match(dep)
+		.with({ kind: "command" }, (d) => isCommandAvailable(d.checkCommand))
+		.with({ kind: "package" }, (d) =>
+			Effect.succeed(canResolveFromCwd(d.packageJson, cwd)),
+		)
+		.exhaustive();
+}
+
 /**
  * Результат проверки зависимостей.
  */
-interface DependencyCheckResult {
+export interface DependencyCheckResult {
 	readonly allAvailable: boolean;
 	readonly missing: readonly Dependency[];
 }
 
 /**
- * Проверяет наличие всех необходимых зависимостей.
+ * Проверяет наличие необходимых зависимостей.
  *
- * @returns Результат проверки
+ * @param cwd Project working directory used for peer resolution
  */
-export function checkDependencies(): Effect.Effect<DependencyCheckResult> {
+export function checkDependencies(
+	cwd: string,
+): Effect.Effect<DependencyCheckResult> {
 	return Effect.gen(function* (_) {
 		const missing: Dependency[] = [];
 
 		for (const dep of DEPENDENCIES) {
-			const available = yield* _(isCommandAvailable(dep.checkCommand));
-			if (!available && dep.required) {
+			const available = yield* _(isDependencyAvailable(dep, cwd));
+			if (!available) {
 				missing.push(dep);
 			}
 		}
@@ -119,18 +130,32 @@ export function checkDependencies(): Effect.Effect<DependencyCheckResult> {
 
 /**
  * Выводит информацию о недостающих зависимостях.
- *
- * @param missing Список недостающих зависимостей
  */
-export function reportMissingDependencies(
-	missing: readonly Dependency[],
-): void {
+export function reportMissingDependencies(params: {
+	readonly cwd: string;
+	readonly packageManager: PackageManager;
+	readonly missing: readonly Dependency[];
+}): void {
 	console.error("\n❌ Missing required dependencies:\n");
 
-	for (const dep of missing) {
-		console.error(`  • ${dep.name} (${dep.command})`);
-		console.error(`    Check: ${dep.checkCommand}`);
-		console.error(`    Install: ${dep.installCommand}\n`);
+	for (const dep of params.missing) {
+		match(dep)
+			.with({ kind: "command" }, (d) => {
+				console.error(`  • ${d.name}`);
+				console.error(`    Check: ${d.checkCommand}`);
+				console.error(`    Install: ${d.installHint}\n`);
+			})
+			.with({ kind: "package" }, (d) => {
+				console.error(`  • ${d.name} (${d.installPackages.join(", ")})`);
+				console.error(`    Resolve: ${d.packageJson}`);
+				console.error(
+					`    Install: ${formatInstallDevCommand(
+						params.packageManager,
+						d.installPackages,
+					)}\n`,
+				);
+			})
+			.exhaustive();
 	}
 
 	console.error("Please install the missing dependencies and try again.\n");

--- a/src/shell/utils/jscpd.ts
+++ b/src/shell/utils/jscpd.ts
@@ -1,0 +1,69 @@
+// CHANGE: Add internal jscpd command builder resolved from vibecode-linter dependencies
+// WHY: Do not rely on `npx jscpd` (may download packages, breaks pnpm/yarn expectations)
+// QUOTE(ISSUE #5): "Надо что бы оно поддерживало pnpm, yarn"
+// REF: ISSUE-5
+// PURITY: SHELL (reads filesystem, resolves modules)
+// INVARIANT: If jscpd is installed as a dependency, we run its bin via `node <bin>`
+// COMPLEXITY: O(1)
+
+import { isJSONObject, isString, type JSONValue } from "../../core/json.js";
+import { fs, path } from "./node-mods.js";
+import { resolveModuleFromSelf } from "./node-resolve.js";
+
+function shellQuote(arg: string): string {
+	return `"${arg.replaceAll('"', '\\"')}"`;
+}
+
+function extractJscpdBinFromParsed(
+	parsed: Readonly<Record<string, JSONValue>>,
+	pkgJsonPath: string,
+): string | null {
+	const withBin: { readonly bin?: JSONValue } = parsed;
+	const bin = withBin.bin;
+	if (bin === undefined) return null;
+
+	if (isString(bin)) {
+		return path.resolve(path.dirname(pkgJsonPath), bin);
+	}
+
+	if (!isJSONObject(bin)) {
+		return null;
+	}
+
+	const withJscpd: { readonly jscpd?: JSONValue } = bin;
+	const jscpdBin = withJscpd.jscpd;
+	if (jscpdBin === undefined) return null;
+	if (!isString(jscpdBin)) return null;
+	return path.resolve(path.dirname(pkgJsonPath), jscpdBin);
+}
+
+function resolveJscpdBin(): string | null {
+	const pkgJsonPath = resolveModuleFromSelf("jscpd/package.json");
+	if (pkgJsonPath === null) return null;
+
+	try {
+		const raw = fs.readFileSync(pkgJsonPath, "utf8");
+		const parsed = JSON.parse(raw) as JSONValue;
+		if (!isJSONObject(parsed)) return null;
+		return extractJscpdBinFromParsed(parsed, pkgJsonPath);
+	} catch {
+		return null;
+	}
+}
+
+export function buildJscpdCommand(params: {
+	readonly reportsDir: string;
+	readonly targetPath: string;
+}): string {
+	const bin = resolveJscpdBin();
+	if (bin === null) {
+		// Fail fast with an obvious command. Caller will handle non-zero.
+		return `jscpd --reporters sarif --output ${shellQuote(
+			params.reportsDir,
+		)} ${shellQuote(params.targetPath)}`;
+	}
+
+	return `node ${shellQuote(bin)} --reporters sarif --output ${shellQuote(
+		params.reportsDir,
+	)} ${shellQuote(params.targetPath)}`;
+}

--- a/src/shell/utils/node-resolve.ts
+++ b/src/shell/utils/node-resolve.ts
@@ -1,0 +1,47 @@
+// CHANGE: Add shared Node module resolution helpers for peer dependency detection
+// WHY: Multiple modules (preflight, dependencies) need deterministic "resolve from cwd" without invoking npx
+// QUOTE(ISSUE #5): "Надо что бы оно поддерживало pnpm, yarn"
+// REF: ISSUE-5
+// PURITY: SHELL (uses Node resolver and may throw; wrapped by callers)
+// INVARIANT: Resolution attempts never mutate global module paths
+// COMPLEXITY: O(1) per resolution attempt
+
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+/**
+ * Resolve a module specifier as-if it was required from a given cwd.
+ *
+ * @returns Resolved absolute path, or null if resolution fails.
+ */
+export function resolveModuleFromCwd(
+	moduleName: string,
+	cwd: string,
+): string | null {
+	try {
+		return require.resolve(moduleName, { paths: [cwd] });
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Resolve a module specifier relative to vibecode-linter itself (self node_modules).
+ *
+ * @returns Resolved absolute path, or null if resolution fails.
+ */
+export function resolveModuleFromSelf(moduleName: string): string | null {
+	try {
+		return require.resolve(moduleName);
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Predicate wrapper around resolveModuleFromCwd.
+ */
+export function canResolveFromCwd(moduleName: string, cwd: string): boolean {
+	return resolveModuleFromCwd(moduleName, cwd) !== null;
+}

--- a/src/shell/utils/package-manager.ts
+++ b/src/shell/utils/package-manager.ts
@@ -1,0 +1,106 @@
+// CHANGE: Add package manager detection and command formatting (npm/pnpm/yarn)
+// WHY: vibecode-linter must not rely on npx auto-download behavior; support pnpm/yarn projects deterministically
+// QUOTE(ISSUE #5): "Надо что бы оно поддерживало pnpm, yarn"
+// REF: ISSUE-5
+// PURITY: SHELL (reads filesystem to detect lockfiles/package.json)
+// INVARIANT: Returned package manager is always one of {"npm","pnpm","yarn"}
+// COMPLEXITY: O(h) where h is directory height (find project root)
+
+import { match } from "ts-pattern";
+
+import { isJSONObject, isString, type JSONValue } from "../../core/json.js";
+import { parsePackageManagerField } from "../../core/package-manager.js";
+import type {
+	PackageManager,
+	PackageManagerSelection,
+} from "../../core/types/index.js";
+import { fs, path } from "./node-mods.js";
+
+function readPackageManagerField(projectRoot: string): PackageManager | null {
+	const pkgPath = path.join(projectRoot, "package.json");
+	if (!fs.existsSync(pkgPath)) return null;
+
+	try {
+		const raw = fs.readFileSync(pkgPath, "utf8");
+		const parsed = JSON.parse(raw) as JSONValue;
+		if (!isJSONObject(parsed)) return null;
+
+		const withPm: { readonly packageManager?: JSONValue } = parsed;
+		const pm = withPm.packageManager;
+		if (pm === undefined) return null;
+		if (!isString(pm)) return null;
+
+		return parsePackageManagerField(pm);
+	} catch {
+		return null;
+	}
+}
+
+function detectFromLockfiles(projectRoot: string): PackageManager | null {
+	const pnpmLock = fs.existsSync(path.join(projectRoot, "pnpm-lock.yaml"));
+	const yarnLock = fs.existsSync(path.join(projectRoot, "yarn.lock"));
+	const npmLock =
+		fs.existsSync(path.join(projectRoot, "package-lock.json")) ||
+		fs.existsSync(path.join(projectRoot, "npm-shrinkwrap.json"));
+
+	// CHANGE: Deterministic priority order for mixed lockfiles
+	// WHY: Some repos accidentally commit multiple lockfiles; choose the most specific first
+	// REF: ISSUE-5 (pm selection)
+	return pnpmLock ? "pnpm" : yarnLock ? "yarn" : npmLock ? "npm" : null;
+}
+
+/**
+ * Find nearest ancestor directory that contains package.json.
+ *
+ * Postcondition: returns an absolute path.
+ */
+export function findProjectRoot(startDir: string): string {
+	let dir = path.resolve(startDir);
+	for (;;) {
+		const pkg = path.join(dir, "package.json");
+		if (fs.existsSync(pkg)) return dir;
+		const parent = path.dirname(dir);
+		if (parent === dir) return path.resolve(startDir);
+		dir = parent;
+	}
+}
+
+/**
+ * Resolve effective package manager for a given cwd and optional user selection.
+ *
+ * Invariant: if selection ∈ {npm,pnpm,yarn} it always wins over auto detection.
+ */
+export function resolvePackageManager(params: {
+	readonly cwd: string;
+	readonly selection?: PackageManagerSelection;
+}): { readonly projectRoot: string; readonly packageManager: PackageManager } {
+	const projectRoot = findProjectRoot(params.cwd);
+
+	const forced = params.selection;
+	if (forced !== undefined && forced !== "auto") {
+		return { projectRoot, packageManager: forced };
+	}
+
+	const fromField = readPackageManagerField(projectRoot);
+	if (fromField !== null) {
+		return { projectRoot, packageManager: fromField };
+	}
+
+	const fromLocks = detectFromLockfiles(projectRoot);
+	return { projectRoot, packageManager: fromLocks ?? "npm" };
+}
+
+/**
+ * Format a dev-dependency install command for a package manager.
+ */
+export function formatInstallDevCommand(
+	packageManager: PackageManager,
+	packages: readonly string[],
+): string {
+	const pkgs = packages.join(" ");
+	return match(packageManager)
+		.with("npm", () => `npm install --save-dev ${pkgs}`)
+		.with("pnpm", () => `pnpm add --save-dev ${pkgs}`)
+		.with("yarn", () => `yarn add --dev ${pkgs}`)
+		.exhaustive();
+}

--- a/src/shell/utils/tool-command.ts
+++ b/src/shell/utils/tool-command.ts
@@ -1,0 +1,87 @@
+// CHANGE: Build deterministic tool invocation commands without npx downloads
+// WHY: `npx biome` may download the legacy `biome` package instead of using `@biomejs/biome`; pnpm/yarn need stable local execution
+// QUOTE(ISSUE #5): "Надо что бы оно поддерживало pnpm, yarn"
+// REF: ISSUE-5
+// PURITY: SHELL (depends on filesystem layout and chosen package manager)
+// INVARIANT: If a local binary exists in node_modules/.bin, we always prefer it (no network)
+// COMPLEXITY: O(h) where h is directory height (find local bin upwards)
+
+import { match } from "ts-pattern";
+
+import type { PackageManager } from "../../core/types/index.js";
+import { fs, path } from "./node-mods.js";
+
+function shellQuote(arg: string): string {
+	// CHANGE: Minimal quoting for shell command safety with spaces
+	// WHY: Many paths may contain spaces; double quotes are sufficient for our usage
+	// REF: ISSUE-5 (avoid brittle command rendering)
+	return `"${arg.replaceAll('"', '\\"')}"`;
+}
+
+function binCandidates(binName: string): readonly string[] {
+	// CHANGE: Add Windows-compatible bin name candidates
+	// WHY: node_modules/.bin uses .cmd shims on Windows
+	// REF: Cross-platform Node tooling conventions
+	return process.platform === "win32"
+		? [`${binName}.cmd`, `${binName}.exe`, `${binName}.ps1`, binName]
+		: [binName];
+}
+
+function findLocalBinUpwards(binName: string, startDir: string): string | null {
+	let dir = path.resolve(startDir);
+	for (;;) {
+		const binDir = path.join(dir, "node_modules", ".bin");
+		for (const candidate of binCandidates(binName)) {
+			const p = path.join(binDir, candidate);
+			if (fs.existsSync(p)) return p;
+		}
+
+		const parent = path.dirname(dir);
+		if (parent === dir) return null;
+		dir = parent;
+	}
+}
+
+/**
+ * Build a command string for executing a tool in the current project.
+ *
+ * Strategy:
+ * 1) Prefer a local binary found in node_modules/.bin (walk up from cwd).
+ * 2) If absent, fall back to the selected package manager:
+ *    - pnpm: `pnpm exec <bin> ...`
+ *    - yarn: `yarn run <bin> ...` (works with Yarn PnP)
+ *
+ * For npm when node_modules/.bin is missing, we render a local .bin fallback path; execution will fail fast
+ * if dependencies are not installed, without triggering implicit downloads.
+ */
+export function buildToolCommand(params: {
+	readonly cwd: string;
+	readonly packageManager: PackageManager;
+	readonly bin: string;
+	readonly args: readonly string[];
+}): string {
+	const local = findLocalBinUpwards(params.bin, params.cwd);
+	const renderedArgs =
+		params.args.length === 0 ? "" : ` ${params.args.map(shellQuote).join(" ")}`;
+
+	if (local !== null) {
+		return `${shellQuote(local)}${renderedArgs}`;
+	}
+
+	return match(params.packageManager)
+		.with("pnpm", () => `pnpm exec ${params.bin}${renderedArgs}`)
+		.with("yarn", () => `yarn run ${params.bin}${renderedArgs}`)
+		.with("npm", () => {
+			// CHANGE: Avoid `npx`/`npm exec` because they may implicitly download packages
+			// WHY: We want deterministic execution; if the binary isn't present locally, execution should fail fast
+			// REF: ISSUE-5
+			const fallback = path.join(
+				params.cwd,
+				"node_modules",
+				".bin",
+				binCandidates(params.bin)[0] ?? params.bin,
+			);
+			return `${shellQuote(fallback)}${renderedArgs}`;
+		})
+		.exhaustive();
+}

--- a/test/config/cli.test.ts
+++ b/test/config/cli.test.ts
@@ -107,3 +107,20 @@ describe("parseCLIArgs: boolean flags", () => {
 		expect(opts.noPreflight).toBeTruthy();
 	});
 });
+
+describe("parseCLIArgs: package manager selection", () => {
+	it("--pm pnpm sets packageManager=pnpm", (): void => {
+		const opts = withArgv(["--pm", "pnpm"], () => parseCLIArgs());
+		expect(opts.packageManager).toBe("pnpm");
+	});
+
+	it("--package-manager yarn sets packageManager=yarn", (): void => {
+		const opts = withArgv(["--package-manager", "yarn"], () => parseCLIArgs());
+		expect(opts.packageManager).toBe("yarn");
+	});
+
+	it("invalid package manager value is ignored (auto)", (): void => {
+		const opts = withArgv(["--pm", "bun"], () => parseCLIArgs());
+		expect(opts.packageManager).toBeUndefined();
+	});
+});

--- a/test/types/ts-scope.test.ts
+++ b/test/types/ts-scope.test.ts
@@ -50,7 +50,7 @@ describe("typeScript diagnostics scope (solution-style tsconfig, NodeNext)", () 
 		// Act & Assert: Use Effect.runPromise to execute Effect-based linter
 		return Effect.runPromise(
 			Effect.gen(function* (_) {
-				const msgs = yield* _(getTypeScriptDiagnostics(badFile));
+				const msgs = yield* _(getTypeScriptDiagnostics(badFile, "npm"));
 
 				// Assert: at least one TS2322 reported for bad.ts in the requested subtree
 				expect(msgs.length).toBeGreaterThan(0);
@@ -73,7 +73,7 @@ describe("typeScript diagnostics scope (solution-style tsconfig, NodeNext)", () 
 		// Act & Assert: Use Effect.runPromise to execute Effect-based linter
 		Effect.runPromise(
 			Effect.gen(function* (_) {
-				const msgs = yield* _(getTypeScriptDiagnostics("src/"));
+				const msgs = yield* _(getTypeScriptDiagnostics("src/", "npm"));
 
 				// Assert: diagnostics from bad.ts must not appear when scoping to src/
 				const leaked = msgs.some(


### PR DESCRIPTION
Closes #5.

## What
- Auto-detect package manager (npm/pnpm/yarn) from lockfiles or package.json#packageManager.
- Replace npx-based tool execution with deterministic local execution:
  - Prefer local node_modules/.bin
  - Fallback to pnpm exec / yarn run when appropriate
- Preflight + install hints now print correct commands for the detected PM.
- New flags: --pm <npm|pnpm|yarn> (alias: --package-manager)

## Why
npx can implicitly download packages (e.g. legacy biome@0.3.3), which breaks expectations for pnpm/yarn projects and causes runtime failures.

## Test
- npm test